### PR TITLE
Updates for version lock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vcpkg"]
-	path = vcpkg
-	url = https://github.com/microsoft/vcpkg

--- a/Tasks/TestWindowsTask.cs
+++ b/Tasks/TestWindowsTask.cs
@@ -20,7 +20,8 @@ public sealed class TestWindowsTask : FrostingTask<BuildContext>
         "SHELL32.dll",
         "SHLWAPI.dll",
         "AVICAP32.dll",
-        "bcrypt.dll"
+        "bcrypt.dll",
+        "msvcrt.dll"
     };
 
     public override bool ShouldRun(BuildContext context) => context.IsRunningOnWindows();


### PR DESCRIPTION
Removes vcpkg submodule and adds msvcrt.dll as a valid windows dependency.