### PR TITLE
Test Before Publishing

### DIFF
--- a/Tasks.cs
+++ b/Tasks.cs
@@ -12,6 +12,6 @@ public class TestToolTask : FrostingTask { }
 
 [TaskName("Default")]
 [IsDependentOn(typeof(BuildToolTask))]
-[IsDependentOn(typeof(PublishToolTask))]
 [IsDependentOn(typeof(TestToolTask))]
+[IsDependentOn(typeof(PublishToolTask))]
 public class DefaultTask : FrostingTask { }

--- a/Tasks/TestLinuxTask.cs
+++ b/Tasks/TestLinuxTask.cs
@@ -20,7 +20,14 @@ public sealed class TestLinuxTask : FrostingTask<BuildContext>
 
     public override void Run(BuildContext context)
     {
-        foreach (var filePath in Directory.GetFiles(context.ArtifactsDir))
+        // Ensure there are files to test otherwise this will always pass
+        var files = Directory.GetFiles(context.ArtifactsDir);
+        if (files is null || files.Length == 0)
+        {
+            throw new Exception("There are no files in the artifacts directory to test");
+        }
+
+        foreach (var filePath in files)
         {
             context.Information($"Checking: {filePath}");
             context.StartProcess(

--- a/Tasks/TestMacOSTask.cs
+++ b/Tasks/TestMacOSTask.cs
@@ -8,7 +8,14 @@ public sealed class TestMacOSTask : FrostingTask<BuildContext>
 
     public override void Run(BuildContext context)
     {
-        foreach (var filePath in Directory.GetFiles(context.ArtifactsDir))
+        // Ensure there are files to test otherwise this will always pass
+        var files = Directory.GetFiles(context.ArtifactsDir);
+        if (files is null || files.Length == 0)
+        {
+            throw new Exception("There are no files in the artifacts directory to test");
+        }
+
+        foreach (var filePath in files)
         {
             context.Information($"Checking: {filePath}");
             context.StartProcess(

--- a/Tasks/TestWindowsTask.cs
+++ b/Tasks/TestWindowsTask.cs
@@ -31,7 +31,15 @@ public sealed class TestWindowsTask : FrostingTask<BuildContext>
         var vswhere = new VSWhereLatest(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
         var devcmdPath = vswhere.Latest(new VSWhereLatestSettings()).FullPath + @"\Common7\Tools\vsdevcmd.bat";
 
-        foreach (var filePath in Directory.GetFiles(context.ArtifactsDir))
+
+        // Ensure there are files to test otherwise this will always pass
+        var files = Directory.GetFiles(context.ArtifactsDir);
+        if (files is null || files.Length == 0)
+        {
+            throw new Exception("There are no files in the artifacts directory to test");
+        }
+
+        foreach (var filePath in files)
         {
             context.Information($"Checking: {filePath}");
             context.StartProcess(
@@ -50,7 +58,7 @@ public sealed class TestWindowsTask : FrostingTask<BuildContext>
                 var libPath = output.Trim();
                 if (!libPath.EndsWith(".dll") || libPath.Contains(' '))
                     continue;
-                    
+
                 if (ValidLibs.Contains(libPath))
                 {
                     context.Information($"VALID: {libPath}");


### PR DESCRIPTION
This PR updates the base build steps so that tests are performed before publishing occurs. The tests were also update to ensure there are actually files to test.  This was change due to tests passing when prior builds failed and didn't output anything to artifacts directory.  Tests should not pass in that case either.