### PR TITLE
Fixes Dotnet Tool Pack

### DIFF
--- a/Tasks/PublishPackageTask.cs
+++ b/Tasks/PublishPackageTask.cs
@@ -63,7 +63,7 @@ public sealed class PublishPackageTask : AsyncFrostingTask<BuildContext>
         if (licensePath.EndsWith(".txt")) licenseName += ".txt";
         else if (licensePath.EndsWith(".md")) licenseName += ".md";
 
-        var contentInclude = $"<Content Include=\"binaries\\**\\*\" CopyToOutputDirectory=\"PreserveNewest\" />";
+        var contentInclude = $"<None Include=\"binaries\\**\\*\" CopyToOutputDirectory=\"PreserveNewest\" />";
 
         var projectData = await ReadEmbeddedResourceAsync("MonoGame.Tool.X.txt");
         projectData = projectData.Replace("{X}", context.PackContext.ToolName)


### PR DESCRIPTION
The binaries were added to the generated csproj as `<Content>` which caused the package to pack them in a `/content`, `/contentFiles` and the `/tools` paths inside the NuGet package.

Changing it to `<None>` no properly only includes them relative in the `/tools` path.