### PR TITLE
return exit code from sub program

### DIFF
--- a/Resources/Program.txt
+++ b/Resources/Program.txt
@@ -45,5 +45,11 @@ using (Process? process = Process.Start(startInfo))
     if (process is not null)
     {
         await process.WaitForExitAsync();
+        return process.ExitCode;
+    }
+    else
+    {
+        // unable to start process
+        return 1;
     }
 }


### PR DESCRIPTION
It would be helpful if the dotnet tool invocation returned the same exit code as the wrapped process returns.