### PR TITLE
Add `libmvec.so` to accepted dependencies.

### DIFF
--- a/Tasks/TestLinuxTask.cs
+++ b/Tasks/TestLinuxTask.cs
@@ -11,6 +11,7 @@ public sealed class TestLinuxTask : FrostingTask<BuildContext>
         "libc.so",
         "libm.so",
         "libdl.so",
+        "libmvec.so",
         "libpthread.so",
         "/lib/ld-linux-",
         "/lib64/ld-linux-"


### PR DESCRIPTION
When putting `MonoGame.Tool.Crunch` together we started to see an error from the static linking check.

```
Checking: artifacts/crunch
VALID: linux-vdso.so.1
VALID: libstdc++.so.6
VALID: libm.so.6
INVALID: libmvec.so.1
VALID: libgcc_s.so.1
VALID: libc.so.6
VALID: /lib64/ld-linux-x86-64.so.2
```

Lets add this new library to the valid list as it should be present on most linux systems, since it is part of `glibc`.