### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/Tasks/TestMacOSTask.cs
+++ b/Tasks/TestMacOSTask.cs
@@ -41,6 +41,7 @@ public sealed class TestMacOSTask : FrostingTask<BuildContext>
 
         foreach (var filePath in Directory.GetFiles(dir))
         {
+            if (filePath.Contains(".DS_Store")) continue;
             context.Information($"Checking: {filePath}");
             context.StartProcess(
                 "dyld_info",


### PR DESCRIPTION
These files aren't build artifacts and interrupt the test tasks on macOS.