### PR TITLE
Add windows-arm64 support

### DIFF
--- a/Tasks/PackageTask.cs
+++ b/Tasks/PackageTask.cs
@@ -18,8 +18,8 @@ public sealed class PackageTask : AsyncFrostingTask<BuildContext>
         if (context.BuildSystem().IsRunningOnGitHubActions)
         {
             string[] requiredRids = context.IsUniversalBinary ?
-                ["windows-x64", "linux-x64", "linux-arm64", "osx"] :
-                ["windows-x64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64"];
+                ["windows-x64", "windows-arm64", "linux-x64", "linux-arm64", "osx"] :
+                ["windows-x64", "windows-arm64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64"];
 
             foreach (var rid in requiredRids)
             {
@@ -40,7 +40,11 @@ public sealed class PackageTask : AsyncFrostingTask<BuildContext>
             string rid = string.Empty;
             if (context.IsRunningOnWindows())
             {
-                rid = "windows-x64";
+                rid = RuntimeInformation.ProcessArchitecture switch
+                {
+                    Architecture.Arm or Architecture.Arm64 => "windows-arm64",
+                    _ => "windows-x64"
+                };
             }
             else if (context.IsRunningOnLinux())
             {

--- a/Tasks/PackageTask.cs
+++ b/Tasks/PackageTask.cs
@@ -39,14 +39,6 @@ public sealed class PackageTask : AsyncFrostingTask<BuildContext>
                     context.Warning($"Failed to download artifacts for {rid}, exception: {ex}");
                 }
             }
-            foreach (var dir in context.GetDirectories($"{projectDir}/binaries/*"))
-            {
-                context.Information($"Contents of {dir}:");
-                foreach (var file in context.GetFiles($"{dir}/**/*"))
-                {
-                    context.Information($" - {file}");
-                }
-            }
         }
         else
         {

--- a/Tasks/PublishToolTask.cs
+++ b/Tasks/PublishToolTask.cs
@@ -28,6 +28,20 @@ public sealed class PublishToolTask : AsyncFrostingTask<BuildContext>
         var copyToDir = $"artifacts-{rid}";
         if (context.BuildSystem().IsRunningOnGitHubActions)
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // we need to upload each rid of windows separately.
+                var directories = Directory.GetDirectories(context.ArtifactsDir, "windows-*");
+                if (directories.Any())
+                {
+                    foreach (var dir in directories)
+                    {
+                        var dirName = new DirectoryInfo(dir).Name;
+                        await context.BuildSystem().GitHubActions.Commands.UploadArtifact(DirectoryPath.FromString(dir), dirName);
+                    }
+                    return;
+                }
+            }
             await context.BuildSystem().GitHubActions.Commands.UploadArtifact(DirectoryPath.FromString(context.ArtifactsDir), copyToDir);
         }
         else

--- a/Tasks/PublishToolTask.cs
+++ b/Tasks/PublishToolTask.cs
@@ -10,11 +10,19 @@ public sealed class PublishToolTask : AsyncFrostingTask<BuildContext>
     {
         var rid = "";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            rid = "windows";
+            rid = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.Arm or Architecture.Arm64 => "windows-arm64",
+                _ => "windows-x64",
+            };
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             rid = "osx";
         else
-            rid = "linux";
+            rid = RuntimeInformation.ProcessArchitecture switch
+            {
+                Architecture.Arm or Architecture.Arm64 => "linux-arm64",
+                _ => "linux-x64",
+            };
 
         if (!(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && context.IsUniversalBinary))
         {

--- a/Tasks/PublishToolTask.cs
+++ b/Tasks/PublishToolTask.cs
@@ -10,19 +10,11 @@ public sealed class PublishToolTask : AsyncFrostingTask<BuildContext>
     {
         var rid = "";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            rid = RuntimeInformation.ProcessArchitecture switch
-            {
-                Architecture.Arm or Architecture.Arm64 => "windows-arm64",
-                _ => "windows-x64",
-            };
+            rid = "windows";
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             rid = "osx";
         else
-            rid = RuntimeInformation.ProcessArchitecture switch
-            {
-                Architecture.Arm or Architecture.Arm64 => "linux-arm64",
-                _ => "linux-x64",
-            };
+            rid = "linux";
 
         if (!(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && context.IsUniversalBinary))
         {

--- a/Tasks/PublishToolTask.cs
+++ b/Tasks/PublishToolTask.cs
@@ -37,7 +37,7 @@ public sealed class PublishToolTask : AsyncFrostingTask<BuildContext>
                     foreach (var dir in directories)
                     {
                         var dirName = new DirectoryInfo(dir).Name;
-                        await context.BuildSystem().GitHubActions.Commands.UploadArtifact(DirectoryPath.FromString(dir), dirName);
+                        await context.BuildSystem().GitHubActions.Commands.UploadArtifact(DirectoryPath.FromString(dir), $"artifacts-{dirName}");
                     }
                     return;
                 }


### PR DESCRIPTION
Update the scripts to handle uploading arm64 binaries for windows. 
The odd thing where was we needed to upload the windows-x64 and windows-arm64 as separate artefacts otherwise they don't end up in the right place in the final nuget. 